### PR TITLE
Add custom mailhost class.

### DIFF
--- a/ftw/testing/mailhost.py
+++ b/ftw/testing/mailhost.py
@@ -1,0 +1,70 @@
+from Products.CMFPlone.tests.utils import MockMailHost as DefaultMockMailHost
+from Products.MailHost.MailHost import _mungeHeaders
+from persistent.list import PersistentList
+
+
+class MockMessage(object):
+
+    def __init__(self, mfrom, mto, messageText):
+        self.mfrom = mfrom
+        self.mto = mto
+        self.messageText = messageText
+
+
+class MockMailHost(DefaultMockMailHost):
+    """Remembers senders and recipient of messages.
+
+    Provides utility methods to access mails by sender/recipient.
+    """
+
+    def reset(self):
+        self._messages = PersistentList()
+
+    def _send(self, mfrom, mto, messageText, immediate=False):
+        self._messages.append(MockMessage(mfrom, mto, messageText))
+
+    def send(self, messageText, mto=None, mfrom=None, subject=None,
+             encode=None, immediate=False, charset=None, msg_type=None):
+        messageText, mto, mfrom = _mungeHeaders(messageText,
+                                                mto, mfrom, subject,
+                                                charset=charset,
+                                                msg_type=msg_type)
+        self._send(mfrom, mto, messageText)
+
+    def pop(self):
+        return self._messages.pop().messageText
+
+    def get_messages_by_sender(self):
+        """Return the messages by sender.
+        """
+
+        result = dict()
+        for each in self._messages:
+            if not each.mfrom in result:
+                result[each.mfrom] = []
+            result[each.mfrom].append(each.messageText)
+        return result
+
+    def get_messages_by_recipient(self):
+        """Return the messages by recipient.
+        """
+
+        result = dict()
+        for each in self._messages:
+            for recipient in each.mto:
+                if not recipient in result:
+                    result[recipient] = []
+                result[recipient].append(each.messageText)
+        return result
+
+    def get_messages(self):
+        """Return a list of message texts.
+        """
+
+        return [each.messageText for each in self._messages]
+
+    def has_messages(self):
+        """Return whether there are outgoing messages.
+        """
+
+        return len(self._messages) > 0

--- a/ftw/testing/mailing.py
+++ b/ftw/testing/mailing.py
@@ -16,7 +16,7 @@ class Mailing(object):
 
         # Do NOT move the MockMailHost import to the top!
         # It patches things implicitly!
-        from Products.CMFPlone.tests.utils import MockMailHost
+        from ftw.testing.mailhost import MockMailHost
 
         mockmailhost = MockMailHost('MailHost')
         self.portal.MailHost = mockmailhost
@@ -31,7 +31,7 @@ class Mailing(object):
     def tear_down(self):
         # Do NOT move the MockMailHost import to the top!
         # It patches things implicitly!
-        from Products.CMFPlone.tests.utils import MockMailHost
+        from ftw.testing.mailhost import MockMailHost
 
         sm = self.portal.getSiteManager()
         mailhost = sm.getUtility(IMailHost)
@@ -43,7 +43,7 @@ class Mailing(object):
 
         # Do NOT move the MockMailHost import to the top!
         # It patches things implicitly!
-        from Products.CMFPlone.tests.utils import MockMailHost
+        from ftw.testing.mailhost import MockMailHost
 
         assert isinstance(mailhost, MockMailHost), \
             'The mailhost mocking was not set up properly. ' \
@@ -51,13 +51,19 @@ class Mailing(object):
         return mailhost
 
     def get_messages(self):
-        return self.get_mailhost().messages
+        return self.get_mailhost().get_messages()
+
+    def get_messages_by_recipient(self):
+        return self.get_mailhost().get_messages_by_recipient()
+
+    def get_messages_by_sender(self):
+        return self.get_mailhost().get_messages_by_sender()
 
     def has_messages(self):
-        return len(self.get_messages()) > 0
+        return self.get_mailhost().has_messages()
 
     def pop(self):
-        return self.get_messages().pop()
+        return self.get_mailhost().pop()
 
     def reset(self):
         # self.get_mailhost().reset()

--- a/ftw/testing/tests/test_mailing.py
+++ b/ftw/testing/tests/test_mailing.py
@@ -10,18 +10,68 @@ class TestMailing(TestCase):
     layer = PAGE_OBJECT_FUNCTIONAL
 
     def setUp(self):
-        Mailing(self.layer['portal']).set_up(configure=True)
+        self.mailing = Mailing(self.layer['portal'])
+        self.mailing.set_up(configure=True)
+        self.mailhost = getUtility(IMailHost)
 
     def tearDown(self):
         Mailing(self.layer['portal']).tear_down()
 
-    def test_mailing_mock(self):
-        mailhost = getUtility(IMailHost)
-        mailhost.send(messageText='Hello World',
-                      mto='info@4teamwork.ch',
-                      mfrom='info@4teamwork.ch',
-                      subject='A test mail from ftw.testing')
+    def _send_test_mail(self, mto='info@4teamwork.ch',
+                        mfrom='info@4teamwork.ch'):
+        self.mailhost.send(messageText='Hello World',
+                           mto=mto,
+                           mfrom=mfrom,
+                           subject='A test mail from ftw.testing')
 
+    def test_reset(self):
+        self.assertEqual(0, len(self.mailing.get_messages()))
+        self._send_test_mail()
+        self.assertEqual(1, len(self.mailing.get_messages()))
+        self.mailing.reset()
+        self.assertEqual(0, len(self.mailing.get_messages()))
+
+    def test_has_messages(self):
+        self.assertFalse(self.mailhost.has_messages())
+        self._send_test_mail()
+        self.assertTrue(self.mailhost.has_messages())
+
+    def test_pop_from_empty_list_fails(self):
+        self.assertRaises(IndexError, self.mailing.pop)
+
+    def test_pop_from_filled_list(self):
+        self._send_test_mail()
+        message = self.mailing.pop()
+        self.assertIn('info@4teamwork.ch', message)
+
+    def test_get_messages_by_recipient(self):
+        self._send_test_mail()
+        self._send_test_mail()
+        self._send_test_mail(mto='foo@example.com')
+
+        messages = self.mailing.get_messages_by_recipient()
+        self.assertEqual(2, len(messages), 'expected two recipients')
+        self.assertIn('foo@example.com', messages)
+        self.assertIn('info@4teamwork.ch', messages)
+
+        self.assertEqual(2, len(messages['info@4teamwork.ch']))
+        self.assertEqual(1, len(messages['foo@example.com']))
+
+    def test_get_messages_by_sender(self):
+        self._send_test_mail()
+        self._send_test_mail()
+        self._send_test_mail(mfrom='foo@example.com')
+
+        messages = self.mailing.get_messages_by_sender()
+        self.assertEqual(2, len(messages), 'expected two senders')
+        self.assertIn('foo@example.com', messages)
+        self.assertIn('info@4teamwork.ch', messages)
+
+        self.assertEqual(2, len(messages['info@4teamwork.ch']))
+        self.assertEqual(1, len(messages['foo@example.com']))
+
+    def test_mailing_mock(self):
+        self._send_test_mail()
         self.assertTrue(Mailing(self.layer['portal']).has_messages(),
                         'There should be one message in the MockMailHost,'
                         ' but there was none.')


### PR DESCRIPTION
The custom mailhost remembers sender and recipient for each mail
separately and provides utility functions to get mails grouped by
sender or recipient.

This is useful for blackbox-tests when multiple mails might be sent during one test.
