### PR TITLE
Add schemata helpers on AT form page object.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- AT form page object: add schemata helper methods for testing visible
+  schematas and fields.
+  [jone]
 
 
 1.4 (2013-08-26)

--- a/ftw/testing/testing.py
+++ b/ftw/testing/testing.py
@@ -8,7 +8,7 @@ from zope.configuration import xmlconfig
 
 class PageObjectLayer(PloneSandboxLayer):
 
-    defaultBases = (PLONE_FIXTURE, )
+    defaultBases = (PLONE_FIXTURE,)
 
     def setUpZope(self, app, configurationContext):
         import plone.app.dexterity
@@ -28,5 +28,5 @@ class PageObjectLayer(PloneSandboxLayer):
 
 PAGE_OBJECT_FIXTURE = PageObjectLayer()
 PAGE_OBJECT_FUNCTIONAL = FunctionalSplinterTesting(
-    bases=(PAGE_OBJECT_FIXTURE, PLONE_ZSERVER),
+    bases=(PAGE_OBJECT_FIXTURE, PLONE_ZSERVER, ),
     name="ftw.testing:pageobject:functional")

--- a/ftw/testing/tests/test_atformpage.py
+++ b/ftw/testing/tests/test_atformpage.py
@@ -1,0 +1,59 @@
+from ftw.testing.pages import Plone
+from ftw.testing.testing import PAGE_OBJECT_FUNCTIONAL
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import setRoles
+from unittest2 import TestCase
+import transaction
+
+
+class TestATFormPage(TestCase):
+
+    layer = PAGE_OBJECT_FUNCTIONAL
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Contributor', 'Member'])
+        transaction.commit()
+
+    def test_schemata_labels_on_page(self):
+        form = (Plone()
+                .login()
+                .visit_portal()
+                .open_add_form('Page'))
+
+        ignore_schematas = (
+            'Ownership',  # Plone <= 4.1
+            'Creators',  # Plone >= 4.2
+            )
+
+        self.assertEquals(
+            ['Default', 'Categorization', 'Dates', 'Settings'],
+
+            filter(lambda label: label not in ignore_schematas,
+                   form.schemata_labels))
+
+    def test_schemata_field_labels_on_page(self):
+        form = (Plone()
+                .login()
+                .visit_portal()
+                .open_add_form('Page'))
+
+        self.assertEquals(['Title', 'Summary', 'Body Text'],
+                          form.schemata_field_labels['Default'])
+
+    def test_schemata_field_labels_on_image(self):
+        # The image widget has a different structure.
+        form = (Plone()
+                .login()
+                .visit_portal()
+                .open_add_form('Image'))
+
+        self.assertIn('Image', form.schemata_field_labels['Default'])
+
+    def test_field_labels_on_page(self):
+        form = (Plone()
+                .login()
+                .visit_portal()
+                .open_add_form('Page'))
+
+        self.assertIn('Title', form.field_labels)


### PR DESCRIPTION
Add schemata helper methods for testing visible schematas and fields on AT forms.

@maethu can you take a look at this? I need to test which schematas and which fields per schemata are visible.
