### PR TITLE
Generic Setup test: use quickinstaller for uninstalling.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -359,9 +359,6 @@ The options are configured as class variables:
 **install_profile_name** (``default``)
     The Generic Setup install profile name postfix.
 
-**uninstall_profile_name** (``uninstall``)
-    The Generic Setup uninstall profile name postfix.
-
 **skip_files** (``()``)
     An iterable of Generic Setup files (e.g. ``("viewlets.xml",)``) to be
     ignored in the diff. This is sometimes necessary, because not all
@@ -388,7 +385,6 @@ Full example:
         additional_zcml_packages = ('my.package', 'my.package.tests')
         additional_products = ('another.package', )
         install_profile_name = 'default'
-        uninstall_profile_name = 'uninstall'
         skip_files = ('viewlets.xml', 'rolemap.xml')
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Generic Setup test: use quickinstaller for uninstalling.
+  [jone]
 
 
 1.6.1 (2014-04-29)

--- a/ftw/testing/genericsetup.py
+++ b/ftw/testing/genericsetup.py
@@ -83,15 +83,15 @@ class GenericSetupUninstallMixin(object):
     additional_products = ()
     install_dependencies = True
     install_profile_name = 'default'
-    uninstall_profile_name = 'uninstall'
     skip_files = ()
 
     def test_uninstall_profile_removes_resets_configuration(self):
         setup_tool = getToolByName(self.layer['portal'], 'portal_setup')
+        quick_installer_tool = getToolByName(self.layer['portal'],
+                                             'portal_quickinstaller')
+
         install_profile_id = 'profile-{0}:{1}'.format(
             self.package, self.install_profile_name)
-        uninstall_profile_id = 'profile-{0}:{1}'.format(
-            self.package, self.uninstall_profile_name)
 
         if self.install_dependencies:
             for profile in setup_tool.getDependenciesForProfile(
@@ -101,7 +101,7 @@ class GenericSetupUninstallMixin(object):
         setup_tool.createSnapshot('before-install')
         setup_tool.runAllImportStepsFromProfile(install_profile_id,
                                                 ignore_dependencies=True)
-        setup_tool.runAllImportStepsFromProfile(uninstall_profile_id)
+        quick_installer_tool.uninstallProducts([self.package])
         setup_tool.createSnapshot('after-uninstall')
 
         before = setup_tool._getImportContext('snapshot-before-install')


### PR DESCRIPTION
We should use the quickinstaller tool to uninstall the package in the test.
This is the usual way to uninstall a package.

@deiferni 
