### PR TITLE
Add patcher for disabling quickinstaller snappshotting in tests.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -381,6 +381,63 @@ Full example:
         skip_files = ('viewlets.xml', 'rolemap.xml')
 
 
+Disabling quickinstaller snapshots
+----------------------------------
+
+Quickinstaller normally makes a complete Generic Setup (GS) snapshot
+before and after installing each GS profile, in order to be able to
+uninstall the profile afterwards.
+
+In tests we usually don't need this feature and want to disable it to
+speed up tests.
+
+The ``ftw.testing.quickinstaller`` module provides a patcher for
+replacing the quickinstaller event handlers to skip creating snapshots.
+Usually we want to do this early (when loading ``testing.py``), so that
+all the tests are speeding up.
+However, some tests which involve quickinstaller rely on having the
+snapshots made (see previous section about uninstall tests).
+Therefore the snapshot patcher object provides context managers for
+temporarily enabling / disabling the snapshot feature.
+
+Usage:
+
+Disable snapshots early, so that everything is fast. Usually this is
+done in the ``testing.py`` in module scope, so that it happens already
+when the testrunner imports the tests:
+
+.. code:: python
+
+  from ftw.testing.quickinstaller import snapshots
+  from plone.app.testing import PloneSandboxLayer
+
+  snapshots.disable()
+
+  class MyPackageLayer(PloneSandboxLayer):
+  ...
+
+When testing quickinstaller snapshot related things, such as uninstalling,
+the snapshots can be re-enabled for a context manager or in general:
+
+.. code:: Python
+  from ftw.testing.quickinstaller import snapshots
+
+  snapshots.disable()
+  # snapshotting is now disabled
+
+  with snapshots.enabled():
+      # snapshotting is enabled only within this block
+
+  snapshots.enable()
+  # snapshotting is now enabled
+
+  with snapshots.disabled():
+      # snapshotting is disabled only within this block
+
+
+
+
+
 Compatibility
 -------------
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add patcher for disabling quickinstaller snappshotting in tests.
+  [jone]
 
 
 1.6.4 (2014-05-01)

--- a/ftw/testing/genericsetup.py
+++ b/ftw/testing/genericsetup.py
@@ -1,13 +1,14 @@
-from Products.CMFCore.utils import getToolByName
-from Products.CMFQuickInstallerTool.InstalledProduct import InstalledProduct
+from ftw.testing.quickinstaller import snapshots
 from plone.app.testing import IntegrationTesting
+from plone.app.testing import login
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
+from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login
-from plone.app.testing import setRoles
 from plone.testing.z2 import installProduct
+from Products.CMFCore.utils import getToolByName
+from Products.CMFQuickInstallerTool.InstalledProduct import InstalledProduct
 from zope.configuration import xmlconfig
 
 
@@ -147,7 +148,8 @@ class GenericSetupUninstallMixin(object):
         self._install_dependencies()
 
         self._create_before_snapshot()
-        self._install_package()
+        with snapshots.enabled():
+            self._install_package()
         self._quickinstaller_uninstall_package()
         self._create_after_shapshot()
 
@@ -158,7 +160,8 @@ class GenericSetupUninstallMixin(object):
         self._install_dependencies()
 
         self._create_before_snapshot()
-        self._install_package()
+        with snapshots.enabled():
+            self._install_package()
         self._setuptool_uninstall_package()
         self._create_after_shapshot()
 

--- a/ftw/testing/quickinstaller.py
+++ b/ftw/testing/quickinstaller.py
@@ -1,0 +1,94 @@
+from contextlib import contextmanager
+from Products.CMFQuickInstallerTool import events
+import inspect
+
+
+def noop_event_handler(event):
+    """An event handler that does nothing.
+    """
+
+
+class QuickInstallerSnapshots(object):
+    """Patches Products.CMFQuickInstallerTool:
+    Removes the quickinstaller's subscribers to GenericSetup events
+    which create snapshots for each installed profile.
+
+    The snapshots are used for uninstalling products, which is usually
+    not done in tests.
+
+    Creating the snapshots consume quite a lot of time.
+    Disabling it speeds up the testing layer setup time.
+    """
+
+    def __init__(self):
+        self._current_version = 'original'
+        self._functions = {}
+
+        self._prepare(events.handleBeforeProfileImportEvent, noop_event_handler)
+        self._prepare(events.handleProfileImportedEvent, noop_event_handler)
+
+    def is_enabled(self):
+        """Returns ``True`` when snapshots are
+        enabled (original implementation).
+        """
+        return self._current_version == 'original'
+
+    def disable(self):
+        """Disable quickinstaller snapshots in general.
+        """
+        self._apply('noop')
+
+    def enable(self):
+        """Enable quickinstaller snapshots in general, when disabled.
+        """
+        self._apply('original')
+
+    @contextmanager
+    def disabled(self):
+        """While in this context manager, snapshots are disabled.
+        """
+        if self.is_enabled():
+            self.disable()
+            try:
+                yield
+            finally:
+                self.enable()
+        else:
+            yield
+
+    @contextmanager
+    def enabled(self):
+        """While in this context manager, snapshots are enabled.
+        """
+        if not self.is_enabled():
+            self.enable()
+            try:
+                yield
+            finally:
+                self.disable()
+        else:
+            yield
+
+    def _apply(self, version):
+        if self._current_version == version:
+            return
+
+        self._current_version = version
+        for dottedname, info in self._functions.items():
+            print 'ftw.testing PATCHING: {0} with {1}'.format(
+                dottedname, version)
+            info['function'].func_code = info[version]
+
+    def _prepare(self, func, replacement):
+        dottedname = '.'.join((func.__module__, func.__name__))
+        original_code = func.func_code
+        replacement_source = inspect.getsource(replacement)
+        exec replacement_source in func.func_globals
+        replacement_code = func.func_globals[replacement.__name__].func_code
+
+        self._functions[dottedname] = {'original': original_code,
+                                       'noop': replacement_code,
+                                       'function': func}
+
+
+snapshots = QuickInstallerSnapshots()

--- a/ftw/testing/testing.py
+++ b/ftw/testing/testing.py
@@ -1,9 +1,13 @@
 from ftw.testing import FunctionalSplinterTesting
+from ftw.testing.quickinstaller import snapshots
+from plone.app.testing import applyProfile
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PLONE_ZSERVER
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import applyProfile
 from zope.configuration import xmlconfig
+
+
+snapshots.disable()
 
 
 class PageObjectLayer(PloneSandboxLayer):


### PR DESCRIPTION
Quickinstaller normally makes a complete Generic Setup (GS) snapshot before and after installing each GS profile, in order to be able to uninstall the profile afterwards.

In tests we usually don't need this feature and want to disable it to speed up tests.

The `ftw.testing.quickinstaller` module provides a patcher for replacing the quickinstaller event handlers to skip creating snapshots.
Usually we want to do this early (when loading `testing.py`), so that all the tests are speeding up.
However, some tests which involve quickinstaller rely on having the snapshots made (see previous section about uninstall tests).
Therefore the snapshot patcher object provides context managers for temporarily enabling / disabling the snapshot feature.

**Usage:**

Disable snapshots early, so that everything is fast. Usually this is
done in the `testing.py` in module scope, so that it happens already
when the testrunner imports the tests:

``` python
from ftw.testing.quickinstaller import snapshots
from plone.app.testing import PloneSandboxLayer

snapshots.disable()

class MyPackageLayer(PloneSandboxLayer):
```

When testing quickinstaller snapshot related things, such as uninstalling, the snapshots can be re-enabled for a context manager or in general:

``` python
from ftw.testing.quickinstaller import snapshots

snapshots.disable()
# snapshotting is now disabled

with snapshots.enabled():
    # snapshotting is enabled only within this block

snapshots.enable()
# snapshotting is now enabled

with snapshots.disabled():
    # snapshotting is disabled only within this block
```
