### PR TITLE
Declare missing dependency to p.a.testing

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Declare missing dependency to p.a.testing
+  required by the COMPONENT_REGISTRY_ISOLATION layer.
+  [jone]
 
 
 1.8.0 (2014-12-31)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ tests_require = [
     'Plone',
     'Products.PloneHotfix20121106',
     'plone.app.dexterity',
-    'plone.app.testing',
     'zc.recipe.egg',
     ] + extras_require['splinter']
 
@@ -56,6 +55,7 @@ setup(name='ftw.testing',
 
       install_requires=[
         'setuptools',
+        'plone.app.testing',
         'plone.mocktestcase',
         'plone.testing',
         'unittest2',


### PR DESCRIPTION
The new ``COMPONENT_REGISTRY_ISOLATION`` testing layer introduced a dependency to p.a.testing, which was not properly declared.