### PR TITLE
Remove dependency to Products.PloneHotfix20121106 and tests.

### DIFF
--- a/ftw/testing/tests/test_testcase.py
+++ b/ftw/testing/tests/test_testcase.py
@@ -236,33 +236,3 @@ class TestSetUpError(MockTestCase):
     def test_stub_response(self):
         with self.assertRaises(RuntimeError):
             self.stub_response()
-
-
-class TestToolMocking(MockTestCase):
-
-    def test_mock_tool_replaces_patch(self):
-        self.assertEquals(getToolByName.__name__, 'getToolByName')
-        self.assertEquals(utils.getToolByName.__name__, 'getToolByName')
-
-        import Products.PloneHotfix20121106
-        Products.PloneHotfix20121106  # pyflakes
-        self.assertEquals(utils.getToolByName.__name__,
-                          'wrapped_getToolByName')
-
-        catalog = self.mocker.mock()
-        self.expect(catalog()).result(['brains']).count(2)
-        self.mock_tool(catalog, 'portal_catalog')
-
-        self.assertNotEquals(type(getToolByName).__name__, 'Mock')
-        self.assertNotEquals(type(utils.getToolByName).__name__, 'Mock')
-
-        self.replay()
-
-        self.assertEquals(type(getToolByName).__name__, 'Mock')
-        self.assertEquals(type(utils.getToolByName).__name__, 'Mock')
-
-        self.assertEqual(utils.getToolByName(None, 'portal_catalog')(),
-                         ['brains'])
-
-        self.assertEqual(getToolByName(None, 'portal_catalog')(),
-                         ['brains'])

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ extras_require = {
 tests_require = [
     'Acquisition<4.0a1',
     'Plone',
-    'Products.PloneHotfix20121106',
     'plone.app.dexterity',
     'zc.recipe.egg',
     ] + extras_require['splinter']


### PR DESCRIPTION
The TestToolMocking test suite depends on having Products.PloneHotfix20121106,
which is bad because those hotfixes are incorporated in the newest Plone hotfix releases.
This causes the test to break on Plone 4.2 because the hotfix does no longer apply.

This removes the regression test which tests that getToolByName is mocked and released
properly even when it is patched before by a hotfix.
We cannot test this properly for all supported Plone versions because the hotfix does
not apply.
It is also not a good idea to have a dependency on a hotfix when test the latest
hotfix versions, since the required hotfixes change.