### PR TITLE
Implement staticuids decorator.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -300,6 +300,34 @@ and supports the Zope `DateTime` module. It removes the patches when exiting
 the context manager.
 
 
+Static UUIDS
+------------
+
+When asserting UUIDs it can be annoying that they change at each test run.
+The ``staticuid`` decorator helps to fix that by using static uuids which
+are prefixed and counted within a scope, usually a test case:
+
+.. code:: python
+
+  from ftw.testing import staticuid
+  from plone.app.testing import PLONE_INTEGRATION_TESTING
+  from unittest2 import TestCase
+
+  class MyTest(TestCase):
+      layer = PLONE_INTEGRATION_TESTING
+
+      @staticuid()
+      def test_all_the_things(self):
+          doc = self.portal.get(self.portal.invokeFactory('Document', 'the-document'))
+          self.assertEquals('testallthethings0000000000000001', IUUID(doc))
+
+      @staticuid('MyUIDS')
+      def test_a_prefix_can_be_set(self):
+          doc = self.portal.get(self.portal.invokeFactory('Document', 'the-document'))
+          self.assertEquals('MyUIDS00000000000000000000000001', IUUID(doc))
+
+
+
 Generic Setup uninstall test
 ----------------------------
 

--- a/ftw/testing/__init__.py
+++ b/ftw/testing/__init__.py
@@ -1,5 +1,6 @@
 from ftw.testing.freezer import freeze
 from ftw.testing.layer import ComponentRegistryLayer
+from ftw.testing.staticuids import staticuid
 from ftw.testing.testcase import MockTestCase
 import pkg_resources
 

--- a/ftw/testing/staticuids.py
+++ b/ftw/testing/staticuids.py
@@ -1,0 +1,37 @@
+from plone.testing import zca
+from plone.uuid.interfaces import IUUIDGenerator
+from zope.component import getGlobalSiteManager
+from zope.interface import implements
+import re
+
+
+def staticuid(prefix=None):
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            zca.pushGlobalRegistry()
+            try:
+                register_static_uid_uitility(prefix=prefix or func.__name__)
+                return func(*args, **kwargs)
+            finally:
+                zca.popGlobalRegistry()
+        return wrapper
+    return decorator
+
+
+class StaticUUIDGenerator(object):
+    implements(IUUIDGenerator)
+
+    def __init__(self, prefix):
+        self.prefix = prefix[:26]
+        self.counter = 0
+
+    def __call__(self):
+        self.counter += 1
+        postfix = str(self.counter).rjust(32 - len(self.prefix), '0')
+        return self.prefix + postfix
+
+
+def register_static_uid_uitility(prefix):
+    prefix = re.sub(r'[^a-zA-Z0-9]', '', prefix)
+    generator = StaticUUIDGenerator(prefix)
+    getGlobalSiteManager().registerUtility(component=generator)

--- a/ftw/testing/tests/test_staticuids.py
+++ b/ftw/testing/tests/test_staticuids.py
@@ -1,0 +1,29 @@
+from ftw.testing import staticuid
+from plone.app.testing import PLONE_INTEGRATION_TESTING
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.uuid.interfaces import IUUID
+from unittest2 import TestCase
+
+
+class TestStaticUIDS(TestCase):
+    layer = PLONE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+
+    @staticuid()
+    def test_uid_generation(self):
+        doc = self.portal.get(self.portal.invokeFactory('Document', 'the-document'))
+        self.assertEquals('testuidgeneration000000000000001', IUUID(doc))
+
+    @staticuid('MyUIDS')
+    def test_uid_generation_with_custom_prefix(self):
+        doc = self.portal.get(self.portal.invokeFactory('Document', 'the-document'))
+        self.assertEquals('MyUIDS00000000000000000000000001', IUUID(doc))
+
+    @staticuid()
+    def test_that_a_very_long_method_name_used_as_prefix_is_cropped(self):
+        doc = self.portal.get(self.portal.invokeFactory('Document', 'the-document'))
+        self.assertEquals('testthataverylongmethodnam000001', IUUID(doc))


### PR DESCRIPTION
The static uid decorator allows to replace the uid generator utility temporaryily with a static uid generator, so that we can easily assert uids in tests.

Example:
```python
from ftw.testing import staticuid
from plone.app.testing import PLONE_INTEGRATION_TESTING
from unittest2 import TestCase

class MyTest(TestCase):
    layer = PLONE_INTEGRATION_TESTING

    @staticuid()
    def test_all_the_things(self):
        doc = self.portal.get(self.portal.invokeFactory('Document', 'the-document'))
        self.assertEquals('testallthethings0000000000000001', IUUID(doc))

    @staticuid('MyUIDS')
    def test_a_prefix_can_be_set(self):
        doc = self.portal.get(self.portal.invokeFactory('Document', 'the-document'))
        self.assertEquals('MyUIDS00000000000000000000000001', IUUID(doc))
```

@maethu