### PR TITLE
Update the freezed time with "forward" and "backward".

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -299,6 +299,25 @@ The ``freeze`` context manager patches the `datetime` module, the `time` module
 and supports the Zope `DateTime` module. It removes the patches when exiting
 the context manager.
 
+**Updating the freezed time**
+
+.. code:: python
+
+    from ftw.testing import freeze
+    from datetime import datetime
+
+    with freeze(datetime(2014, 5, 7, 12, 30)) as clock:
+        # its 2014, 5, 7, 12, 30
+        clock.forward(days=2)
+        # its 2014, 5, 9, 12, 30
+        clock.backward(minutes=15)
+        # its 2014, 5, 9, 12, 15
+
+You can use the
+`timedelta arguments`(https://docs.python.org/2/library/datetime.html#datetime.timedelta)_
+for ``forward`` and ``backward``.
+
+
 
 Static UUIDS
 ------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.9.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Update the freezed time with ``forward`` and ``backward``.
+  [jone]
 
 
 1.9.1 (2015-05-15)

--- a/ftw/testing/freezer.py
+++ b/ftw/testing/freezer.py
@@ -12,6 +12,16 @@ class FreezedClock(object):
     def __init__(self, new_now):
         self.new_now = new_now
 
+    def forward(self, **kwargs):
+        self.new_now = datetime.now() + timedelta(**kwargs)
+        self.__exit__(None, None, None)
+        self.__enter__()
+
+    def backward(self, **kwargs):
+        self.new_now = datetime.now() - timedelta(**kwargs)
+        self.__exit__(None, None, None)
+        self.__enter__()
+
     def __enter__(self):
         if type(self.new_now) != datetime:
             raise ValueError(
@@ -47,6 +57,7 @@ class FreezedClock(object):
         expect(time_class()).call(lambda: new_time).count(0, None)
 
         self.mocker.replay()
+        return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.mocker.restore()

--- a/ftw/testing/freezer.py
+++ b/ftw/testing/freezer.py
@@ -1,48 +1,59 @@
 from contextlib import contextmanager
 from datetime import datetime
+from datetime import timedelta
+from mocker import expect
 from mocker import Mocker
 from mocker import ProxyReplacer
-from mocker import expect
 import calendar
+
+
+class FreezedClock(object):
+
+    def __init__(self, new_now):
+        self.new_now = new_now
+
+    def __enter__(self):
+        if type(self.new_now) != datetime:
+            raise ValueError(
+                'The freeze_date argument must be a datetime.datetime'
+                ' instance, got %s' % type(self.new_now).__name__)
+
+        self.mocker = Mocker()
+
+        # Manually create a proxy mock class for overwriting "now"
+        class datetime_class(datetime):
+            @staticmethod
+            def now():
+                return self.new_now
+            __mocker_object__ = datetime
+            __mocker_replace__ = False
+
+        event = self.mocker._get_replay_restore_event()
+        event.add_task(ProxyReplacer(datetime_class))
+
+        # Rebuild the new_now so that it is an instance of the mocked class
+        self.new_now = datetime_class(*self.new_now.timetuple()[:-3]
+                                       + (self.new_now.microsecond,))
+
+        # Replace "datetime" module
+        datetime_module = self.mocker.replace('datetime', spec=False)
+        expect(datetime_module.datetime).result(datetime_class).count(0, None)
+
+        # Replace "time" class
+        new_time = (calendar.timegm(self.new_now.timetuple()) +
+                    (self.new_now.timetuple().tm_isdst * 60 * 60) +
+                    (self.new_now.microsecond * 0.000001))
+        time_class = self.mocker.replace('time.time')
+        expect(time_class()).call(lambda: new_time).count(0, None)
+
+        self.mocker.replay()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.mocker.restore()
+        self.mocker.verify()
 
 
 @contextmanager
 def freeze(new_now):
-    if type(new_now) != datetime:
-        raise ValueError(
-            'The freeze_date argument must be a datetime.datetime'
-            ' instance, got %s' % type(new_now).__name__)
-
-    mocker = Mocker()
-
-    # Manually create a proxy mock class for overwriting "now"
-    class datetime_class(datetime):
-        @staticmethod
-        def now():
-            return new_now
-        __mocker_object__ = datetime
-        __mocker_replace__ = False
-
-    event = mocker._get_replay_restore_event()
-    event.add_task(ProxyReplacer(datetime_class))
-
-    # Rebuild the new_now so that it is an instance of the mocked class
-    new_now = datetime_class(*new_now.timetuple()[:-3] + (new_now.microsecond,))
-
-    # Replace "datetime" module
-    datetime_module = mocker.replace('datetime', spec=False)
-    expect(datetime_module.datetime).result(datetime_class).count(0, None)
-
-    # Replace "time" class
-    new_time = (calendar.timegm(new_now.timetuple()) +
-                (new_now.timetuple().tm_isdst * 60 * 60) +
-                (new_now.microsecond * 0.000001))
-    time_class = mocker.replace('time.time')
-    expect(time_class()).call(lambda: new_time).count(0, None)
-
-    mocker.replay()
-    try:
-        yield
-    finally:
-        mocker.restore()
-        mocker.verify()
+    with FreezedClock(new_now) as clock:
+        yield clock

--- a/ftw/testing/tests/test_freezer.py
+++ b/ftw/testing/tests/test_freezer.py
@@ -88,3 +88,21 @@ class TestFreeze(TestCase):
         with freeze(datetime.datetime(2010, 10, 20)):
             self.assertTrue(isinstance(datetime.datetime.now(),
                                        datetime_class))
+
+    def test_update_freezed_time_forwards(self):
+        with freeze(datetime.datetime(2010, 10, 20)) as clock:
+            self.assertEquals(datetime.datetime(2010, 10, 20),
+                              datetime.datetime.now())
+
+            clock.forward(days=1)
+            self.assertEquals(datetime.datetime(2010, 10, 21),
+                              datetime.datetime.now())
+
+    def test_update_freezed_time_backwards(self):
+        with freeze(datetime.datetime(2010, 10, 20)) as clock:
+            self.assertEquals(datetime.datetime(2010, 10, 20),
+                              datetime.datetime.now())
+
+            clock.backward(days=2)
+            self.assertEquals(datetime.datetime(2010, 10, 18),
+                              datetime.datetime.now())


### PR DESCRIPTION
The ``forward`` and ``backward`` methods allows to easily update the freezed time.

```python
from ftw.testing import freeze
from datetime import datetime

with freeze(datetime(2014, 5, 7, 12, 30)) as clock:
    # its 2014, 5, 7, 12, 30
    clock.forward(days=2)
    # its 2014, 5, 9, 12, 30
    clock.backward(minutes=15)
    # its 2014, 5, 9, 12, 15
```