### PR TITLE
Freezer: add commit support

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.10.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Freezer bugfix: replace datetime instances when leaving freeze context manager.
+  [jone]
 
 
 1.10.2 (2015-07-30)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.10.3 (unreleased)
 -------------------
 
+- Freezer: disable freezing while committing to database for preventing pickling errors.
+  [jone]
+
 - Freezer bugfix: replace datetime instances when leaving freeze context manager.
   [jone]
 

--- a/ftw/testing/tests/test_freezer.py
+++ b/ftw/testing/tests/test_freezer.py
@@ -1,5 +1,6 @@
 from DateTime import DateTime
 from ftw.testing import freeze
+from plone.app.testing import PLONE_FUNCTIONAL_TESTING
 from plone.mocktestcase.dummy import Dummy
 from unittest2 import TestCase
 import datetime
@@ -150,3 +151,20 @@ class TestFreeze(TestCase):
                                 dummy.datetime_class.__name__)),
              'instance': '.'.join((type(dummy.date).__module__,
                                    type(dummy.date).__name__))})
+
+
+class TestFreezeIntegration(TestCase):
+    layer = PLONE_FUNCTIONAL_TESTING
+
+    def test_commit_works_with_transactions(self):
+        with freeze(datetime.datetime(2015, 7, 22, 11, 45, 58)):
+            self.layer['portal'].current_date = datetime.datetime.now()
+            transaction.commit()
+
+        transaction.begin()
+
+        thedate = self.layer['portal'].current_date
+        self.assertEquals(datetime.datetime(2015, 7, 22, 11, 45, 58), thedate)
+        self.assertEquals('datetime.datetime',
+                          '.'.join((type(thedate).__module__,
+                                    type(thedate).__name__)))

--- a/ftw/testing/tests/test_freezer.py
+++ b/ftw/testing/tests/test_freezer.py
@@ -1,9 +1,11 @@
 from DateTime import DateTime
 from ftw.testing import freeze
+from plone.mocktestcase.dummy import Dummy
 from unittest2 import TestCase
 import datetime
 import pytz
 import time
+import transaction
 
 datetime_module = datetime
 datetime_class = datetime.datetime
@@ -134,3 +136,17 @@ class TestFreeze(TestCase):
             clock.forward(hours=1)
             after = datetime.datetime.now()
             self.assertEquals(60 * 60, (after - before).seconds)
+
+    def test_patches_are_removed_from_freezed_instances(self):
+        with freeze():
+            dummy = Dummy(datetime_class=datetime.datetime,
+                          date=datetime.datetime.now())
+
+        self.assertEquals(
+            {'class': 'datetime.datetime',
+             'instance': 'datetime.datetime'},
+
+            {'class': '.'.join((dummy.datetime_class.__module__,
+                                dummy.datetime_class.__name__)),
+             'instance': '.'.join((type(dummy.date).__module__,
+                                   type(dummy.date).__name__))})


### PR DESCRIPTION
**Problem:**
When committing objects with freezed dates, there were pickling errors, such as:
```python
Traceback (most recent call last):
  File "/Users/jone/projects/python/cache/eggs/unittest2-0.5.1-py2.7.egg/unittest2/case.py", line 340, in run
    testMethod()
  File "/Users/jone/projects/packages/ftw.testing/ftw/testing/tests/test_freezer.py", line 162, in test_commit_works_with_transactions
    transaction.commit()
  File "/Users/jone/projects/python/cache/eggs/transaction-1.1.1-py2.7.egg/transaction/_manager.py", line 89, in commit
    return self.get().commit()
  File "/Users/jone/projects/python/cache/eggs/transaction-1.1.1-py2.7.egg/transaction/_transaction.py", line 329, in commit
    self._commitResources()
  File "/Users/jone/projects/python/cache/eggs/transaction-1.1.1-py2.7.egg/transaction/_transaction.py", line 443, in _commitResources
    rm.commit(self)
  File "/Users/jone/projects/python/cache/eggs/ZODB3-3.10.5-py2.7-macosx-10.4-x86_64.egg/ZODB/Connection.py", line 567, in commit
    self._commit(transaction)
  File "/Users/jone/projects/python/cache/eggs/ZODB3-3.10.5-py2.7-macosx-10.4-x86_64.egg/ZODB/Connection.py", line 623, in _commit
    self._store_objects(ObjectWriter(obj), transaction)
  File "/Users/jone/projects/python/cache/eggs/ZODB3-3.10.5-py2.7-macosx-10.4-x86_64.egg/ZODB/Connection.py", line 658, in _store_objects
    p = writer.serialize(obj)  # This calls __getstate__ of obj
  File "/Users/jone/projects/python/cache/eggs/ZODB3-3.10.5-py2.7-macosx-10.4-x86_64.egg/ZODB/serialize.py", line 422, in serialize
    return self._dump(meta, obj.__getstate__())
  File "/Users/jone/projects/python/cache/eggs/ZODB3-3.10.5-py2.7-macosx-10.4-x86_64.egg/ZODB/serialize.py", line 431, in _dump
    self._p.dump(state)
PicklingError: Can't pickle <class 'ftw.testing.freezer.datetime_class'>: attribute lookup ftw.testing.freezer.datetime_class failed
```

The problem is that the datetime objects are instances of our datetime mock class, which is not serializable.
We also do not want to store those objects but we want to store real datetime objects.

**Fixes:**
- When disabling freezing (=leaving context manager), we reconstruct all datetime objects which are instances of the datetime mock class and replace all pointers using the garbage collector.
- Before committing, we disable freezing and activate it after committing again.

@mbaechtold 
/cc @lukasgraf 