### PR TITLE
Add transaction interceptor.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -353,6 +353,39 @@ the snapshots can be re-enabled for a context manager or in general:
       # snapshotting is disabled only within this block
 
 
+Transaction interceptor
+-----------------------
+
+The ``TransactionInterceptor`` patches Zope's transaction manager in
+order to prevent code from interacting with the transaction.
+
+This can be used for example for making sure that no tests commit transactions
+when they are running on an integration testing layer.
+
+The interceptor needs to be installed manually with ``install()`` and removed
+at the end with ``uninstall()``. It is the users responsibility to ensure
+proper uninstallation.
+
+When the interceptor is installed, it is not yet active and passes through all
+calls.
+The intercepting begins with ``intercept()`` and ends when ``clear()`` is
+called.
+
+.. code:: python
+
+    from ftw.testing import TransactionInterceptor
+
+    interceptor = TransactionInterceptor().install()
+    try:
+        interceptor.intercept(interceptor.BEGIN | interceptor.COMMIT
+                              | interceptor.ABORT)
+        # ...
+        interceptor.clear()
+        transaction.abort()
+    finally:
+        interceptor.uninstall()
+
+
 Testing Layers
 --------------
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.12.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add transaction interceptor. [jone]
 
 
 1.12.0 (2017-06-19)

--- a/ftw/testing/__init__.py
+++ b/ftw/testing/__init__.py
@@ -2,6 +2,7 @@ from ftw.testing.freezer import freeze
 from ftw.testing.layer import ComponentRegistryLayer
 from ftw.testing.staticuids import staticuid
 from ftw.testing.testcase import MockTestCase
+from ftw.testing.transaction_interceptor import TransactionInterceptor
 import pkg_resources
 
 

--- a/ftw/testing/exceptions.py
+++ b/ftw/testing/exceptions.py
@@ -1,0 +1,5 @@
+
+
+class Intercepted(Exception):
+    """A transaction interaction attempt was intercepted.
+    """

--- a/ftw/testing/tests/test_transaction_interceptor.py
+++ b/ftw/testing/tests/test_transaction_interceptor.py
@@ -1,0 +1,120 @@
+from ftw.testing import TransactionInterceptor
+from ftw.testing.exceptions import Intercepted
+from ftw.testing.testing import FTW_TESTING_FUNCTIONAL
+from unittest2 import TestCase
+import transaction
+
+
+class TestTransactionInterceptor(TestCase):
+    layer = FTW_TESTING_FUNCTIONAL
+
+    def tearDown(self):
+        if hasattr(transaction.manager, 'uninstall'):
+            transaction.manager.uninstall()
+
+    def test_intercept_begin(self):
+        transaction.begin()  # not intercepted
+
+        interceptor = TransactionInterceptor().install()
+        transaction.begin()  # not intercepted
+
+        interceptor.intercept(interceptor.BEGIN)
+        with self.assertRaises(Intercepted) as cm:
+            transaction.begin()  # intercepted
+
+        self.assertEquals('Not allowed to transaction.begin() at the moment.',
+                          str(cm.exception))
+
+        interceptor.clear()
+        transaction.begin()  # not intercepted
+
+        interceptor.uninstall()
+        transaction.begin()  # not intercepted
+
+    def test_intercept_commit(self):
+        transaction.commit()  # not intercepted
+
+        interceptor = TransactionInterceptor().install()
+        transaction.commit()  # not intercepted
+
+        interceptor.intercept(interceptor.COMMIT)
+        with self.assertRaises(Intercepted) as cm:
+            transaction.commit()  # intercepted
+
+        self.assertEquals('Not allowed to transaction.commit() at the moment.',
+                          str(cm.exception))
+
+        interceptor.clear()
+        transaction.commit()  # not intercepted
+
+        interceptor.uninstall()
+        transaction.commit()  # not intercepted
+
+    def test_intercept_abort(self):
+        transaction.abort()  # not intercepted
+
+        interceptor = TransactionInterceptor().install()
+        transaction.abort()  # not intercepted
+
+        interceptor.intercept(interceptor.ABORT)
+        with self.assertRaises(Intercepted) as cm:
+            transaction.abort()  # intercepted
+
+        self.assertEquals('Not allowed to transaction.abort() at the moment.',
+                          str(cm.exception))
+
+        interceptor.clear()
+        transaction.abort()  # not intercepted
+
+        interceptor.uninstall()
+        transaction.abort()  # not intercepted
+
+    def test_intercept_multiple_methods_in_one_call(self):
+        interceptor = TransactionInterceptor().install()
+        transaction.begin()
+        transaction.commit()
+        transaction.abort()
+
+        interceptor.intercept(interceptor.COMMIT | interceptor.ABORT)
+        transaction.begin()
+        with self.assertRaises(Intercepted):
+            transaction.commit()
+        with self.assertRaises(Intercepted):
+            transaction.abort()
+
+        interceptor.uninstall()
+
+    def test_intercept_multiple_methods_by_extending(self):
+        interceptor = TransactionInterceptor().install()
+        transaction.begin()
+        transaction.commit()
+        transaction.abort()
+
+        interceptor.intercept(interceptor.COMMIT)
+        interceptor.intercept(interceptor.ABORT)
+        transaction.begin()
+        with self.assertRaises(Intercepted):
+            transaction.commit()
+        with self.assertRaises(Intercepted):
+            transaction.abort()
+
+        interceptor.uninstall()
+
+    def test_intercepts_on_transaction(self):
+        interceptor = TransactionInterceptor().install()
+        interceptor.intercept(interceptor.COMMIT | interceptor.ABORT)
+
+        txn = transaction.get()
+        with self.assertRaises(Intercepted):
+            txn.commit()
+        with self.assertRaises(Intercepted):
+            txn.abort()
+
+    def test_not_installable_twice(self):
+        TransactionInterceptor().install()
+        with self.assertRaises(Exception) as cm:
+            TransactionInterceptor().install()
+
+        self.assertEqual('Cannot install TransactionInterceptor,'
+                         ' there is already one installed.',
+                         str(cm.exception))

--- a/ftw/testing/transaction_interceptor.py
+++ b/ftw/testing/transaction_interceptor.py
@@ -1,0 +1,126 @@
+from ftw.testing.exceptions import Intercepted
+import transaction
+
+
+class TransactionInterceptor(object):
+    """The ``TransactionInterceptor`` patches Zope's transaction manager in
+    order to prevent code from interacting with the transaction.
+
+    This can be used for example for making sure that no tests commit transactions
+    when they are running on an integration testing layer.
+
+    The interceptor needs to be installed manually with ``install()`` and removed
+    at the end with ``uninstall()``. It is the users responsibility to ensure
+    proper uninstallation.
+
+    When the interceptor is installed, it is not yet active and passes through all
+    calls.
+    The intercepting begins with ``intercept()`` and ends when ``clear()`` is
+    called.
+    """
+
+    BEGIN = 1
+    COMMIT = 2
+    ABORT = 4
+
+    def __init__(self):
+        self._intercepting = 0
+        self._manager = None
+
+    def install(self):
+        """Patch the interceptor into Zope's transaction module.
+        """
+        if isinstance(transaction.manager, type(self)):
+            raise Exception('Cannot install TransactionInterceptor,'
+                            ' there is already one installed.')
+
+        self._manager = transaction.manager
+        transaction.manager = self
+        transaction.get = self.get
+        transaction.__enter__ = self.get
+        transaction.begin = self.begin
+        transaction.commit = self.commit
+        transaction.abort = self.abort
+        transaction.__exit__ = self.__exit__
+        transaction.doom = self.doom
+        transaction.isDoomed = self.isDoomed
+        transaction.savepoint = self.savepoint
+        transaction.attempts = self.attempts
+        return self
+
+    def uninstall(self):
+        """Remove patches.
+        """
+        transaction.manager = self._manager
+        transaction.get = self._manager.get
+        transaction.__enter__ = self._manager.get
+        transaction.begin = self._manager.begin
+        transaction.commit = self._manager.commit
+        transaction.abort = self._manager.abort
+        transaction.__exit__ = self._manager.__exit__
+        transaction.doom = self._manager.doom
+        transaction.isDoomed = self._manager.isDoomed
+        transaction.savepoint = self._manager.savepoint
+        transaction.attempts = self._manager.attempts
+        del self._manager
+        return self
+
+    def intercept(self, methods):
+        if not isinstance(methods, int):
+            raise ValueError('Use the binary flags, e.g. interceptor.BEGIN')
+        self._intercepting |= methods
+        return self
+
+    def clear(self):
+        self._intercepting = 0
+        return self
+
+    def begin(self):
+        if self._intercepting & self.BEGIN:
+            raise Intercepted('Not allowed to transaction.begin() at the moment.')
+        return self._manager.begin()
+
+    def commit(self):
+        if self._intercepting & self.COMMIT:
+            raise Intercepted('Not allowed to transaction.commit() at the moment.')
+        return self._manager.commit()
+
+    def abort(self):
+        if self._intercepting & self.ABORT:
+            raise Intercepted('Not allowed to transaction.abort() at the moment.')
+        return self._manager.abort()
+
+    def get(self):
+        return TransactionWrapper(self._manager.get(), self)
+
+    def __exit__(self, *args, **kwargs):
+        return self._manager.__exit__(*args, **kwargs)
+
+    def __getattr__(self, attr):
+        if attr in dir(type(self)) or attr in vars(self):
+            return object.__getattribute__(self, attr)
+        else:
+            return self._manager.__getattribute__(attr)
+
+
+class TransactionWrapper(object):
+
+    def __init__(self, transaction, manager):
+        self._transaction = transaction
+        self._manager = manager
+
+    def commit(self):
+        if self._manager._intercepting & self._manager.COMMIT:
+            raise Intercepted('Not allowed to commit transaction at the moment.')
+        return self._transaction.commit()
+
+    def abort(self):
+        if self._manager._intercepting & self._manager.ABORT:
+            raise Intercepted('Not allowed to abort transaction at the moment.')
+        return self._transaction.abort()
+
+    def __getattr__(self, attr):
+        if attr in dir(type(self)) or attr in vars(self):
+            return object.__getattribute__(self, attr)
+        else:
+            return self._transaction.__getattribute__(attr)


### PR DESCRIPTION
The ``TransactionInterceptor`` patches Zope's transaction manager in order to prevent code from interacting with the transaction.

This can be used for example for making sure that no tests commit transactions when they are running on an integration testing layer.

The interceptor needs to be installed manually with ``.install()`` and removed at the end with ``.uninstall``. It is the users responsibility to ensure proper uninstallation.

When the interceptor is installed, it is not yet active and passes through all calls. The intercepting begins when ``.intercept()`` and ends when ``.clear()`` is called.

```python
from ftw.testing import TransactionInterceptor

interceptor = TransactionInterceptor().install()
try:
    interceptor.intercept(interceptor.BEGIN | interceptor.COMMIT | interceptor.ABORT)
    # ...
    interceptor.clear()
    transaction.abort()
finally:
    interceptor.uninstall()
```