### PR TITLE
Do not require "Plone" egg.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.13.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Do not require "Plone" egg. [jone]
 
 
 1.13.0 (2017-06-20)

--- a/ftw/testing/__init__.py
+++ b/ftw/testing/__init__.py
@@ -6,4 +6,4 @@ from ftw.testing.transaction_interceptor import TransactionInterceptor
 import pkg_resources
 
 
-IS_PLONE_5 = pkg_resources.get_distribution('Plone').version >= '5'
+IS_PLONE_5 = pkg_resources.get_distribution('Products.CMFPlone').version >= '5'

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ maintainer = 'Jonas Baumann'
 
 extras_require = {}
 tests_require = [
-    'Plone',
     'plone.app.dexterity',
     'zc.recipe.egg',
     ]


### PR DESCRIPTION
The Plone package is a wrapper package which is not installed by default in Plone tests. We should rely on "Products.CMFPlone", not on "Plone".