### PR TITLE
Add savepoint simulation to transaction interceptor.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.14.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add savepoint simulation to transaction interceptor. [jone]
 
 
 1.14.0 (2017-06-23)


### PR DESCRIPTION
Extend the transaction interceptor with a savepoint simulation mode. The savepoint simulation mode simulates a transaction by using a savepoint in order to be able to roll back.

This will help in situations where transaction commits cannot be avoided but should not be executed.