### PR TITLE
Fix savepoint simulation to cleanup savepoints.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.15.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix savepoint simulation to cleanup savepoints. [jone]
 
 
 1.15.0 (2017-07-03)

--- a/ftw/testing/tests/test_transaction_interceptor.py
+++ b/ftw/testing/tests/test_transaction_interceptor.py
@@ -204,3 +204,13 @@ class TestTransactionInterceptor(TestCase):
 
         with self.assertRaises(Intercepted):
             transaction.commit()
+
+    def test_savepoint_simulation_resets_savepoint_on_exit(self):
+        interceptor = TransactionInterceptor().install()
+        interceptor.intercept(interceptor.COMMIT)
+
+        with interceptor.savepoint_simulation():
+            transaction.begin()
+            self.assertTrue(interceptor._savepoint)
+
+        self.assertIsNone(interceptor._savepoint)

--- a/ftw/testing/transaction_interceptor.py
+++ b/ftw/testing/transaction_interceptor.py
@@ -83,6 +83,7 @@ class TransactionInterceptor(object):
 
     def stop_savepoint_simulation(self):
         self._savepoint_simulation = False
+        self._savepoint = None
 
     @contextmanager
     def savepoint_simulation(self):


### PR DESCRIPTION
The savepoint simulation clenaup so that it removes the savepoint. This is important when the interceptor is resued later when the prior savepoint is no longer valid.