### PR TITLE
Freezer: keep timezone info when moving clock forward / backward.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.15.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Freezer: keep timezone info when moving clock forward / backward. [jone]
 
 
 1.15.1 (2017-07-04)

--- a/ftw/testing/freezer.py
+++ b/ftw/testing/freezer.py
@@ -13,12 +13,12 @@ class FreezedClock(object):
         self.new_now = new_now
 
     def forward(self, **kwargs):
-        self.new_now = datetime.now() + timedelta(**kwargs)
+        self.new_now += timedelta(**kwargs)
         self.__exit__(None, None, None)
         self.__enter__()
 
     def backward(self, **kwargs):
-        self.new_now = datetime.now() - timedelta(**kwargs)
+        self.new_now -= timedelta(**kwargs)
         self.__exit__(None, None, None)
         self.__enter__()
 

--- a/ftw/testing/tests/test_freezer.py
+++ b/ftw/testing/tests/test_freezer.py
@@ -63,7 +63,17 @@ class TestFreeze(TestCase):
             ' instance, got int')
 
     def test_handles_tzinfo_correctly(self):
-        with freeze(datetime.datetime(2015, 1, 1, 7, 15, tzinfo=pytz.UTC)):
+        with freeze(datetime.datetime(2015, 1, 1, 7, 15, tzinfo=pytz.UTC)) as clock:
+            self.assertEquals(
+                datetime.datetime(2015, 1, 1, 7, 15, tzinfo=pytz.UTC),
+                datetime.datetime.now(pytz.UTC))
+
+            clock.forward(days=1)
+            self.assertEquals(
+                datetime.datetime(2015, 1, 2, 7, 15, tzinfo=pytz.UTC),
+                datetime.datetime.now(pytz.UTC))
+
+            clock.backward(days=1)
             self.assertEquals(
                 datetime.datetime(2015, 1, 1, 7, 15, tzinfo=pytz.UTC),
                 datetime.datetime.now(pytz.UTC))


### PR DESCRIPTION
When freezing a specific datetime with a tzinfo, the tzinfo should be keept when moving the clock forward and backward.

The timezone info was lost when using `.forward()` and `.backward()` because it used `datetime.now()` as basis, which returns a timezone naïve object. By using the actually freezed datetime object we always have the same timezone (or none) after moving the clock.