### PR TITLE
Freezer: Fix DST-bug in today() and time().

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.15.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Freezer: Fix DST-bug in today() and time(). [jone]
 
 
 1.15.1 (2017-07-04)

--- a/ftw/testing/freezer.py
+++ b/ftw/testing/freezer.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from forbiddenfruit import curse
 from mocker import expect
 from mocker import Mocker
-import calendar
+from time import mktime
 
 
 class FreezedClock(object):
@@ -45,9 +45,7 @@ class FreezedClock(object):
         curse(datetime, 'now', freezed_now)
 
         # Replace "time.time" function
-        new_time = (calendar.timegm(self.new_now.timetuple()) +
-                    (self.new_now.timetuple().tm_isdst * 60 * 60) +
-                    (self.new_now.microsecond * 0.000001))
+        new_time = mktime(self.new_now.timetuple())
         time_class = self.mocker.replace('time.time')
         expect(time_class()).call(lambda: new_time).count(0, None)
 

--- a/ftw/testing/tests/test_freezer.py
+++ b/ftw/testing/tests/test_freezer.py
@@ -25,7 +25,7 @@ class TestFreeze(TestCase):
 
     def test_time_module_is_patched(self):
         the_date = datetime.datetime(2010, 10, 20)
-        the_time = 1287529200.0
+        the_time = time.mktime(the_date.timetuple())
 
         self.assertLess(the_time, time_module.time())
         with freeze(the_date):
@@ -35,7 +35,7 @@ class TestFreeze(TestCase):
 
     def test_time_function_is_patched(self):
         the_date = datetime.datetime(2010, 10, 20)
-        the_time = 1287529200.0
+        the_time = time.mktime(the_date.timetuple())
 
         self.assertLess(the_time, time_function())
         with freeze(the_date):
@@ -101,6 +101,18 @@ class TestFreeze(TestCase):
             clock.forward(hours=1)
             after = datetime.datetime.now()
             self.assertEquals(60 * 60, (after - before).seconds)
+
+    def test_today_is_now_in_summer(self):
+        now = datetime.datetime(2010, 6, 1)
+        with freeze(now):
+            self.assertEquals(now, datetime.datetime.now())
+            self.assertEquals(now, datetime.datetime.today())
+
+    def test_today_is_now_in_winter(self):
+        now = datetime.datetime(2010, 12, 1)
+        with freeze(now):
+            self.assertEquals(now, datetime.datetime.now())
+            self.assertEquals(now, datetime.datetime.today())
 
 
 class TestFreezeIntegration(TestCase):


### PR DESCRIPTION
The time.time() function was off by one hour when no tzinfo was provided while freezing a summer time. All functions basing on time.time(), such as datetime.today(), were off too.

We now use mktime() for building the time instead of calculating it ourselve. mktime() can handle the case where tm_isdst is -1 (=undecided).

Closes #19