### PR TITLE
Support Plone 5.1 for ConsoleScriptLayer.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 1.15.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Support Plone 5.1 for ConsoleScriptLayer. [jone]
 
 1.15.2 (2017-07-18)
 -------------------

--- a/ftw/testing/layer.py
+++ b/ftw/testing/layer.py
@@ -204,6 +204,8 @@ class ConsoleScriptLayer(Layer):
         if getFSVersionTuple() < (4, 3):
             self.resolve_dependency_versions('manuel', dependencies)
             self.resolve_dependency_versions('zope.hookable', dependencies)
+        if getFSVersionTuple() > (5, 1):
+            self.resolve_dependency_versions('zope.untrustedpython', dependencies)
         return dependencies
 
     def resolve_dependency_versions(self, pkgname, result=None, extras=()):


### PR DESCRIPTION
With Plone 5.1, the testing-buildout used by the ConsoleScriptLayer requires to already have a zope.untrustedpython available.