### PR TITLE
Add FTWIntegrationTesting and FTWIntegrationTestCase.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,74 @@ This package provides helpers for writing tests.
 .. contents:: Table of Contents
 
 
+IntegrationTesting
+------------------
+
+FTWIntegrationTesting layer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``FTWIntegrationTesting`` is an opinionated extension of Plone's
+default integration testing layer.
+
+The primary goal is to be able to run ``ftw.testbrowser``s traversal
+driver with integration testing.
+
+**Database isolation and transactions**
+
+The Plone default integration testing layer does support transactions:
+when changes are committed in tests, no isolation is provided
+and the committed changes will apear in the next layer.
+
+- We isolate between tests by making a savepoint in the test setup and
+  rolling back to the savepoint in test tear down.
+- With a transaction interceptor we make sure that no code in the test
+  can commit or abort a transaction. Transactional behavior is simulated
+  by using savepoints.
+
+
+**Usage example:**
+
+.. code:: python
+
+    from ftw.testing import FTWIntegrationTesting
+    from plone.app.testing import PLONE_FIXTURE
+    from plone.app.testing import PloneSandboxLayer
+
+    class TestingLayer(PloneSandboxLayer):
+        defaultBases = (PLONE_FIXTURE,)
+
+
+    TESTING_FIXTURE = TestingLayer()
+    INTEGRATION_TESTING = FTWIntegrationTesting(
+        bases=(TESTING_FIXTURE,),
+        name='my.package:integration')
+
+
+
+FTWIntegrationTestCase
+~~~~~~~~~~~~~~~~~~~~~~
+
+The integration test case is an test case base class providing sane defaults
+and practical helpers for testing Plone addons with an ``FTWIntegrationTesting``
+testing layer.
+
+You may make your own base class in your package, setting the default testing
+layer and extending the behavior and helpers for your needs.
+
+
+**Usage example:**
+
+.. code:: python
+
+    # my/package/tests/test_case.py
+    from ftw.testing import FTWIntegrationTestCase
+    from my.package.testing import INTEGRATION_TESTING
+
+    class IntegrationTestCase(FTWIntegrationTestCase):
+        layer = INTEGRATION_TESTING
+
+
+
 MockTestCase
 ------------
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 1.16.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Add ``FTWIntegrationTesting`` and ``FTWIntegrationTestCase``. [jone]
 
 1.16.0 (2017-08-08)
 -------------------

--- a/ftw/testing/__init__.py
+++ b/ftw/testing/__init__.py
@@ -1,4 +1,6 @@
 from ftw.testing.freezer import freeze
+from ftw.testing.integration_testing import FTWIntegrationTestCase
+from ftw.testing.integration_testing import FTWIntegrationTesting
 from ftw.testing.layer import ComponentRegistryLayer
 from ftw.testing.staticuids import staticuid
 from ftw.testing.testcase import MockTestCase

--- a/ftw/testing/integration_testing.py
+++ b/ftw/testing/integration_testing.py
@@ -1,0 +1,195 @@
+from AccessControl import getSecurityManager
+from AccessControl.SecurityManagement import setSecurityManager
+from contextlib import contextmanager
+from ftw.testing.transaction_interceptor import TransactionInterceptor
+from functools import wraps
+from plone.app.testing import IntegrationTesting
+from plone.app.testing import login
+from plone.app.testing import logout
+from plone.app.testing import SITE_OWNER_NAME
+from unittest2 import TestCase
+import timeit
+import transaction
+
+
+class FTWIntegrationTesting(IntegrationTesting):
+    """An extended integration testing layer class, extending the Plone
+    default integration testing with opinionated behavior.
+
+    DATABASE ISOLATION AND TRANSACTIONS
+    The Plone default integration testing layer does support transactions:
+    when changes are committed in tests, no isolation is provided
+    and the committed changes will apear in the next layer.
+
+    - We isolate between tests by making a savepoint in the test setup and
+      rolling back to the savepoint in test tear down.
+    - With a transaction interceptor we make sure that no code in the test
+      can commit or abort a transaction. Transactional behavior is simulated
+      by using savepoints.
+    """
+
+    def setUp(self):
+        super(FTWIntegrationTesting, self).setUp()
+        transaction.commit()
+        self.interceptor = TransactionInterceptor().install()
+
+    def tearDown(self):
+        self.interceptor.uninstall()
+        super(FTWIntegrationTesting, self).tearDown()
+
+    def testSetUp(self):
+        super(FTWIntegrationTesting, self).testSetUp()
+        self.makeSavepoint()
+        self.interceptor.intercept(self.interceptor.BEGIN |
+                                   self.interceptor.COMMIT |
+                                   self.interceptor.ABORT)
+        self.interceptor.begin_savepoint_simulation()
+        self.interceptor.begin()
+
+    def testTearDown(self):
+        self.interceptor.stop_savepoint_simulation()
+        self.rollbackSavepoint()
+        self.interceptor.clear().intercept(self.interceptor.COMMIT)
+        super(FTWIntegrationTesting, self).testTearDown()
+
+    def makeSavepoint(self):
+        self.savepoint = transaction.savepoint()
+
+    def rollbackSavepoint(self):
+        self.savepoint.rollback()
+        self.savepoint = None
+
+
+class FTWIntegrationTestCase(TestCase):
+    """An opinionated test case which works well with the FTWIntegrationTesting
+    layer.
+
+    This class may be subclassed as baseclass and extended with a testing layer
+    and custom behavior:
+
+    .. code:: python
+
+    class IntegrationTestCase(FTWIntegrationTestCase):
+        layer = MY_PACKAGE_INTEGRATION_TESTING
+    """
+
+    logout_by_default = True
+
+    def setUp(self):
+        super(FTWIntegrationTestCase, self).setUp()
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        if self.logout_by_default:
+            logout()
+
+    @staticmethod
+    def clock(func):
+        """Decorator for measuring the duration of a test and printing the result.
+        This function is meant to be used temporarily in development.
+
+        Example:
+
+        >>> @FTWIntegrationTestCase.clock
+        ... def test_something(self):
+        ...     pass
+        """
+
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            timer = timeit.default_timer
+            start = timer()
+            try:
+                return func(self, *args, **kwargs)
+            finally:
+                end = timer()
+                print ''
+                print '{}.{} took {:.3f} ms'.format(
+                    type(self).__name__,
+                    func.__name__,
+                    (end - start) * 1000)
+        return wrapper
+
+    def login(self, user, browser=None):
+        """Login a user by setting the security manager.
+
+        The login method logs in a user by creating a new security manager
+        with this user.
+        The ``user`` may be a userid or a user object.
+
+        >>> self.login(acl_users.getUserById('john.doe'))
+        >>> self.login('john.doe')
+
+        The optional ``browser`` keyword argument allows to pass in an
+        ``ftw.testbrowser`` browser instance, which will be logged in with
+        the same user.
+
+        >>> self.login(user_object, browser=browser)
+
+        When the method is used as context manager, the prior security manager
+        will be restored on exit:
+
+        >>> with self.login(admin):
+        ...     do_something_as_admin()
+
+        :param user: A user object or a user name.
+        :type user: string or user object
+        :param browser: A ``ftw.testbrowser`` instance to log in too.
+        :type browser: :py:class:`ftw.testbrowser.core.Browser`
+        """
+
+        if hasattr(user, 'getUserName'):
+            userid = user.getUserName()
+        else:
+            userid = user
+
+        security_manager = getSecurityManager()
+        if userid == SITE_OWNER_NAME:
+            login(self.layer['app'], userid)
+        else:
+            login(self.portal, userid)
+
+        if browser is not None:
+            browser_auth_headers = filter(
+                lambda item: item[0] == 'Authorization',
+                browser.session_headers)
+            browser.login(userid)
+
+        @contextmanager
+        def login_context_manager():
+            try:
+                yield
+            finally:
+                setSecurityManager(security_manager)
+                if browser is not None:
+                    browser.clear_request_header('Authorization')
+                    [browser.append_request_header(name, value)
+                     for (name, value) in browser_auth_headers]
+
+        return login_context_manager()
+
+    @contextmanager
+    def observe_children(self, obj, check_security=True):
+        """Observe the children of an object for testing that children were
+        added or removed within the context manager.
+
+        :param obj: The container to observe.
+        :type obj: Plone object.
+        :param check_security: Only report children allowed to access.
+        :type check_security: bool
+        :returns: A dict which will be updated with result when leaving the
+          context manager.
+        :rtype: dict
+        """
+        if check_security:
+            def allowed(obj):
+                return getSecurityManager().checkPermission(
+                    'Access contents information', obj)
+        else:
+            def allowed(obj):
+                return True
+
+        children = {'before': filter(allowed, obj.objectValues())}
+        yield children
+        children['after'] = filter(allowed, obj.objectValues())
+        children['added'] = set(children['after']) - set(children['before'])
+        children['removed'] = set(children['before']) - set(children['after'])

--- a/ftw/testing/testing.py
+++ b/ftw/testing/testing.py
@@ -1,3 +1,4 @@
+from ftw.testing import FTWIntegrationTesting
 from ftw.testing import IS_PLONE_5
 from ftw.testing.quickinstaller import snapshots
 from plone.app.testing import applyProfile
@@ -44,3 +45,6 @@ FTW_TESTING_FIXTURE = TestingLayer()
 FTW_TESTING_FUNCTIONAL = FunctionalTesting(
     bases=(FTW_TESTING_FIXTURE, PLONE_ZSERVER, ),
     name="ftw.testing:functional")
+FTW_TESTING_INTEGRATION = FTWIntegrationTesting(
+    bases=(FTW_TESTING_FIXTURE, ),
+    name="ftw.testing:integration")

--- a/ftw/testing/tests/test_integration_testing.py
+++ b/ftw/testing/tests/test_integration_testing.py
@@ -1,0 +1,116 @@
+from ftw.testing import FTWIntegrationTestCase
+from ftw.testing import IS_PLONE_5
+from ftw.testing.testing import FTW_TESTING_INTEGRATION
+from plone import api
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+import transaction
+
+
+class TestIntegrationTesting(FTWIntegrationTestCase):
+    layer = FTW_TESTING_INTEGRATION
+
+    def test_zodb_changes_are_isolated_1(self):
+        """This test makes sure that changes applied within a test are not
+        leaking to the next test but are isolated correctly.
+        """
+        self.login(SITE_OWNER_NAME)
+        self.assertEquals('Plone site', self.get_site_title(),
+                          'ZODB changes seem not to be isolated between tests.')
+        self.set_site_title(u'New Site Title')
+        self.assertEquals('New Site Title', self.get_site_title())
+
+    # By duplicating the method pointer on the class this test will be
+    # executed twice. The test is built so that it detects leaks from
+    # a prior run when the isolation does not work.
+    test_zodb_changes_are_isolated_2 = test_zodb_changes_are_isolated_1
+
+    def test_rollback_nested_savepoints(self):
+        """It should be possible to use savepoints in tests, although
+        the testing layer uses savepoints for isolation.
+        """
+        self.login(SITE_OWNER_NAME)
+        self.assertEquals('Plone site', self.get_site_title())
+        savepoint = transaction.savepoint()
+        self.set_site_title(u'Foo')
+        self.assertEquals('Foo', self.get_site_title())
+        savepoint.rollback()
+        self.assertEquals('Plone site', self.get_site_title())
+
+    def set_site_title(self, title):
+        if IS_PLONE_5:
+            getUtility(IRegistry)['plone.site_title'] = title
+        else:
+            self.portal.setTitle(title)
+
+    def get_site_title(self):
+        if IS_PLONE_5:
+            return getUtility(IRegistry)['plone.site_title']
+        else:
+            return self.portal.Title()
+
+
+class TestIntegrationTestCase(FTWIntegrationTestCase):
+    layer = FTW_TESTING_INTEGRATION
+
+    def test_serverside_default_user_is_anonymous(self):
+        """We prefer creating new users with real roles for tests than
+        reusing a testing user and granting additional roles.
+
+        Use ftw.builder or a fixture.
+        """
+        self.assertTrue(api.user.is_anonymous())
+
+    def test_login_with_userid(self):
+        """Login accepts userids.
+        """
+        self.assertTrue(api.user.is_anonymous())
+        self.login(TEST_USER_NAME)
+        self.assertFalse(api.user.is_anonymous())
+        self.assertEqual(TEST_USER_ID, api.user.get_current().getId())
+
+    def test_login_with_user_object(self):
+        """Login accepts a user object.
+        """
+        self.assertTrue(api.user.is_anonymous())
+        self.login(api.user.get(TEST_USER_ID))
+        self.assertFalse(api.user.is_anonymous())
+        self.assertEqual(TEST_USER_ID, api.user.get_current().getId())
+
+    def test_login_as_context_manager(self):
+        """Login can be used as context manager.
+        """
+        self.assertTrue(api.user.is_anonymous())
+
+        with self.login(TEST_USER_NAME):
+            self.assertFalse(api.user.is_anonymous())
+            self.assertEqual(TEST_USER_ID, api.user.get_current().getId())
+
+            with self.login(SITE_OWNER_NAME):
+                self.assertFalse(api.user.is_anonymous())
+                self.assertEqual(SITE_OWNER_NAME, api.user.get_current().getId())
+
+            self.assertFalse(api.user.is_anonymous())
+            self.assertEqual(TEST_USER_ID, api.user.get_current().getId())
+
+        self.assertTrue(api.user.is_anonymous())
+
+    def test_observe_children(self):
+        self.login(SITE_OWNER_NAME)
+
+        container = api.content.create(self.portal, 'Folder', title=u'Container')
+        old = api.content.create(container, 'Folder', title=u'Old')
+        with self.observe_children(container) as children:
+            self.assertEquals({'before': [old]}, children)
+            new = api.content.create(container, 'Folder', title=u'New')
+            api.content.delete(old)
+
+        self.assertEquals(
+            {'before': [old],
+             'removed': {old},
+             'added': {new},
+             'after': [new]},
+            children)

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ maintainer = 'Jonas Baumann'
 
 extras_require = {}
 tests_require = [
+    'plone.api',
     'plone.app.dexterity',
     'zc.recipe.egg',
     ]


### PR DESCRIPTION
The new integration testing layer and its test case help setting up a testing environment with database isolation and transaction handling.
It makes it possible to use ftw.testbrowser's traversal driver with integration testing.
The test case provides helper methods. It can be extended with more useful helpers and assertion methods for testing Plone addons.

The code is mostly copied from `opengever.core`.