### PR TITLE
Extend "staticuid" to also be a context manager.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.17.1 (unreleased)
 -------------------
 
+- Extend ``staticuid`` to also be a context manager. [jone]
 - Also freeze ``datetime.utcnow()``. [Rotonen]
 
 

--- a/ftw/testing/tests/test_staticuids.py
+++ b/ftw/testing/tests/test_staticuids.py
@@ -35,3 +35,16 @@ class TestStaticUIDS(TestCase):
     @staticuid()
     def test_site_hook_is_set(self):
         self.assertTrue(getSite(), 'The site hook (getSite) is not set.')
+
+    def test_staticuid_may_be_used_as_context_manager(self):
+        with staticuid('foo'):
+            one = self.portal.get(self.portal.invokeFactory('Document', 'one'))
+        self.assertEquals('foo00000000000000000000000000001', IUUID(one))
+
+    def test_context_manager_requires_prefix(self):
+        with self.assertRaises(ValueError) as cm:
+            with staticuid():
+                pass
+        self.assertEquals(
+            'A prefix must be defined when using staticuid as a context manager.',
+            str(cm.exception))


### PR DESCRIPTION
It should be possible to use staticuid multiple times within the same function with different prefixes.

staticuid did only support beeing used as function decorator, therefore this use case was only possible by using nested functions, which is not very readable.

With this change staticuid can also be used a context manager, while it can still be used as decorator.