### PR TITLE
Fix bug with getting a timezone aware "now".

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 -------------------
 
 - Drop support for plone 4.2. [jone]
+- Fix bug with getting a timezone aware "now". [njohner]
 
 
 1.18.0 (2018-07-12)

--- a/ftw/testing/freezer.py
+++ b/ftw/testing/freezer.py
@@ -48,8 +48,15 @@ class FreezedClock(object):
         def freezed_now(klass, tz=None):
             if not tz:
                 return self.new_now.replace(tzinfo=None)
+
+            # Time was frozen to a naive DT, but a TZ-aware time is being requested
+            # from now(). We assume the same TZ for freezing as requested by now.
+            elif self.new_now.tzinfo is None:
+                return self.new_now.replace(tzinfo=tz)
+
             elif self.new_now.tzinfo != tz:
                 return tz.normalize(self.new_now.astimezone(tz))
+
             return self.new_now
 
         @classmethod

--- a/ftw/testing/tests/test_freezer.py
+++ b/ftw/testing/tests/test_freezer.py
@@ -103,6 +103,20 @@ class TestFreeze(TestCase):
                 datetime.datetime(2015, 1, 1, 7, 15),
                 datetime.datetime.now())
 
+    def test_now_with_tz_for_freeze_without_tz_returns_timezone_aware_datetime(self):
+        """If Time is frozen with a naive DT, but a TZ-aware time is being requested
+        from now(), we assume the same TZ for freezing as requested by now."""
+        freezed = datetime.datetime(2015, 1, 1, 7, 15)
+
+        with freeze(freezed):
+            self.assertNotEquals(
+                datetime.datetime(2015, 1, 1, 7, 15, tzinfo=pytz.timezone('Europe/Zurich')),
+                datetime.datetime.now(pytz.timezone('US/Eastern')))
+
+            self.assertEquals(
+                datetime.datetime(2015, 1, 1, 7, 15, tzinfo=pytz.timezone('US/Eastern')),
+                datetime.datetime.now(pytz.timezone('US/Eastern')))
+
     def test_update_freezed_time_forwards(self):
         with freeze(datetime.datetime(2010, 10, 20)) as clock:
             self.assertEquals(datetime.datetime(2010, 10, 20),


### PR DESCRIPTION
When freezing with a timezone unaware datetime, getting now for a given timezone would fail. Instead we now assume the same timezome for the freezing time as passed in the "now" method call.

This problem arises in GEVER, when freezing with a timezone unaware `datetime` and then updating a document title, which fires an SQL query with a timezone aware now as `modified` date.

The chosen solution also seems to match with what is done in `freezegun` (https://github.com/spulec/freezegun/)