### PR TITLE
Fix timezone issue in freezer for Zope DateTime.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.19.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix in timezone aware freezing for Zope DateTime. [njohner]
 
 
 1.19.1 (2018-10-23)

--- a/ftw/testing/tests/test_freezer.py
+++ b/ftw/testing/tests/test_freezer.py
@@ -85,14 +85,20 @@ class TestFreeze(TestCase):
             with freeze(dt) as clock:
                 self.assertEquals(dt, datetime.datetime.now(timezone))
                 self.assertEquals(dt_utc, datetime.datetime.utcnow())
+                self.assertEquals(dt, timezone.normalize(DateTime().asdatetime().astimezone(timezone)))
+                self.assertEquals(dt_utc, pytz.UTC.normalize(DateTime().asdatetime()))
 
                 clock.forward(days=1)
                 self.assertEquals(dt_plusone, datetime.datetime.now(timezone))
                 self.assertEquals(dt_plusone_utc, datetime.datetime.utcnow())
+                self.assertEquals(dt_plusone, timezone.normalize(DateTime().asdatetime().astimezone(timezone)))
+                self.assertEquals(dt_plusone_utc, pytz.UTC.normalize(DateTime().asdatetime()))
 
                 clock.backward(days=1)
                 self.assertEquals(dt, datetime.datetime.now(timezone))
                 self.assertEquals(dt_utc, datetime.datetime.utcnow())
+                self.assertEquals(dt, timezone.normalize(DateTime().asdatetime().astimezone(timezone)))
+                self.assertEquals(dt_utc, pytz.UTC.normalize(DateTime().asdatetime()))
 
     def test_now_without_tz_returns_timezone_naive_datetime(self):
         freezed = datetime.datetime(2015, 1, 1, 7, 15,


### PR DESCRIPTION
The freezer freezes the python datetime as well as the system time. The problem is that when freezing the system time, all information about the timezone is lost. Zope DateTime then uses the system time and the local timezone to construct its current time. We fix this by adding the offset to the local timezone to the timetuple when freezing the system time.