### PR TITLE
Optimize ignore_modules to avoid unneeded stack inspections

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.20.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Optimize "ignore_modules" to avoid unneeded stack inspections. [Rotonen]
 
 
 1.20.0 (2019-01-25)

--- a/ftw/testing/freezer.py
+++ b/ftw/testing/freezer.py
@@ -40,9 +40,18 @@ class FreezedClock(object):
                 ' instance, got %s' % type(self.new_now).__name__)
 
         def is_caller_ignored(frames_up):
-            caller_frame = inspect.stack()[frames_up][0]
-            module_name = inspect.getmodule(caller_frame).__name__
-            return module_name in self.ignore_modules
+            """Inspect the stack for n frames up for a blacklisted caller.
+
+            Stack inspection is very expensive, so we skip this per default as
+            we hit this on every access to a frozen time. A fine case example
+            of catastrophic access density is a bunch of Plone workflow event
+            handlers firing off a Dexterity ``createdInContainer`` event.
+            """
+            if self.ignore_modules:
+                caller_frame = inspect.stack()[frames_up][0]
+                module_name = inspect.getmodule(caller_frame).__name__
+                return module_name in self.ignore_modules
+            return False
 
         self.mocker = Mocker()
 


### PR DESCRIPTION
The new stack-inspection-on-read logic of time freezing has proven expensive and has roughly tripled the fixture build time of `opengever.core` from just over one minute to about three and a half minutes. It also seems to have added about a minute to the runtime of the test server self test run.

I've side stepped this by only inspecting the stack if the user has explicitly passed in an iterable of module names to ignore.

Build of current master  of `opengever.core` ~19 minutes:
https://ci.4teamwork.ch/builds/233225

Build of current master of `opengever.core` against this branch ~16 minutes:
https://ci.4teamwork.ch/builds/233238

Two main culprits for this being so heavy:
1) `inspect.stack()` iterates over the `.items()` of potentially very large dictionaries
2) `inspect.getmodule()` hits the disk during module discovery