### PR TITLE
Fix component registry tear down in MockTestCase

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix component registry tear down in MockTestCase. [buchi]
 
 
 2.0.0 (2019-11-11)

--- a/ftw/testing/testcase.py
+++ b/ftw/testing/testcase.py
@@ -10,7 +10,6 @@ from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 import six
 import unittest
 import zope.component
-import zope.component.testing
 import zope.proxy
 
 if six.PY2:
@@ -60,7 +59,6 @@ class BaseMockTestCase(unittest.TestCase):
 
     def tearDown(self):
         super(BaseMockTestCase, self).tearDown()
-        zope.component.testing.tearDown(self)
         self._mocked_tools = {}
         patch_refs(cmf_utils, 'getToolByName', self._original_getToolByName)
 


### PR DESCRIPTION
Do not tear down the component registry in `MockTestCase` as it's
handled by the `ComponentRegistryLayer`.