### PR TITLE
Fixes for uninstall tests: restore diffs, and run in Plone 5.1

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Stop quickinstall_uninstallation test from being skipped on Plone 5.1 [djowett-ftw]
+- restore diffs for uninstall tests after removing unittest2 [djowett-ftw]
 
 
 2.0.4 (2019-12-04)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Stop quickinstall_uninstallation test from being skipped on Plone 5.1 [djowett-ftw]
 
 
 2.0.4 (2019-12-04)

--- a/ftw/testing/genericsetup.py
+++ b/ftw/testing/genericsetup.py
@@ -156,6 +156,8 @@ class GenericSetupUninstallMixin(object):
         after = self.setup_tool._getImportContext('snapshot-' + after_id)
 
         self.maxDiff = None
+        self.longMessage = True
+
         self.assertMultiLineEqual(
             self.setup_tool.compareConfigurations(
                 before, after, skip=self.skip_files).decode('utf8'),

--- a/ftw/testing/genericsetup.py
+++ b/ftw/testing/genericsetup.py
@@ -142,7 +142,7 @@ class GenericSetupUninstallMixin(object):
             registry = getUtility(IRegistry)
             registry.records['plone.resources.last_legacy_import'].value = self.datetime
             registry.records['plone.bundles/plone-legacy.last_compilation'].value = self.datetime
-        
+
     def assertSnapshotsEqual(self, before_id='before-install',
                              after_id='after-uninstall',
                              msg=None):
@@ -162,7 +162,7 @@ class GenericSetupUninstallMixin(object):
             '',
             msg=msg)
 
-    @unittest.skipIf(getFSVersionTuple() > (5, 1), 'Only for Plone < 5.2')
+    @unittest.skipIf(getFSVersionTuple() >= (5, 2), 'Only for Plone < 5.2')
     def test_quickinstall_uninstallation_removes_resets_configuration(self):
         self._install_dependencies()
 


### PR DESCRIPTION
This could unhide some test failures, but unlikely