### PR TITLE
Significantly optimize freezer's "ignore_modules"

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.20.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Significantly optimize freezer's "ignore_modules" by avoiding retrieving the
+  complete call stack.
+  [buchi]
 
 
 1.20.1 (2019-04-04)

--- a/ftw/testing/freezer.py
+++ b/ftw/testing/freezer.py
@@ -48,9 +48,13 @@ class FreezedClock(object):
             handlers firing off a Dexterity ``createdInContainer`` event.
             """
             if self.ignore_modules:
-                caller_frame = inspect.stack()[frames_up][0]
-                module_name = inspect.getmodule(caller_frame).__name__
+                frame = inspect.currentframe()
+                for _ in range(frames_up):
+                    frame = frame.f_back
+
+                module_name = inspect.getmodule(frame).__name__
                 return module_name in self.ignore_modules
+
             return False
 
         self.mocker = Mocker()


### PR DESCRIPTION
This fixes the severe performance problem with opengever.core testserver.
