### PR TITLE
Make freezer's "ignore_modules" more robust.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.0.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make freezer's "ignore_modules" more robust.
+  [phgross]
 
 
 2.0.6 (2020-05-28)

--- a/ftw/testing/freezer.py
+++ b/ftw/testing/freezer.py
@@ -104,9 +104,11 @@ class FreezedClock(object):
                 for _ in range(frames_up):
                     frame = frame.f_back
 
-                    module_name = inspect.getmodule(frame).__name__
-                    if module_name in self.ignore_modules:
-                        return True
+                    module = inspect.getmodule(frame)
+                    if module:
+                        module_name = module.__name__
+                        if module_name in self.ignore_modules:
+                            return True
 
             return False
 


### PR DESCRIPTION
In some cases (template expressions) the module of the current frame can't be get and with the current implementation an `AttributeError: 'NoneType' object has no attribute '__name__'` occurs.

By just handling those callers as not ignored, we can fix this problem.

Problems occurs in opengever.core testserver-selftests when bumping to latest ftw.testing version (see [CA-1240](https://4teamwork.atlassian.net/browse/CA-1240))