### PR TITLE
Fix mailing and genericsetup tests

### DIFF
--- a/ftw/testing/__init__.py
+++ b/ftw/testing/__init__.py
@@ -5,7 +5,9 @@ from ftw.testing.layer import ComponentRegistryLayer
 from ftw.testing.staticuids import staticuid
 from ftw.testing.testcase import MockTestCase
 from ftw.testing.transaction_interceptor import TransactionInterceptor
+from Products.CMFPlone.utils import getFSVersionTuple
 import pkg_resources
 
 
 IS_PLONE_5 = pkg_resources.get_distribution('Products.CMFPlone').version >= '5'
+PLONE_VERSION = getFSVersionTuple()

--- a/ftw/testing/genericsetup.py
+++ b/ftw/testing/genericsetup.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from ftw.testing import IS_PLONE_5
+from ftw.testing import PLONE_VERSION
 from ftw.testing.quickinstaller import snapshots
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import login
@@ -11,7 +12,6 @@ from plone.app.testing import TEST_USER_NAME
 from plone.registry.interfaces import IRegistry
 from plone.testing.z2 import installProduct
 from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import getFSVersionTuple
 from Products.CMFQuickInstallerTool.InstalledProduct import InstalledProduct
 from zope.component import getUtility
 from zope.configuration import xmlconfig
@@ -143,6 +143,11 @@ class GenericSetupUninstallMixin(object):
             registry.records['plone.resources.last_legacy_import'].value = self.datetime
             registry.records['plone.bundles/plone-legacy.last_compilation'].value = self.datetime
 
+            if PLONE_VERSION >= (5, 2, 0):
+                css_ts_record = registry.records['plone.app.theming.interfaces.IThemeSettings.custom_css_timestamp']
+                css_ts_record.value = self.datetime
+                css_ts_record.field.defaultFactory = lambda: self.datetime
+
     def assertSnapshotsEqual(self, before_id='before-install',
                              after_id='after-uninstall',
                              msg=None):
@@ -164,7 +169,7 @@ class GenericSetupUninstallMixin(object):
             '',
             msg=msg)
 
-    @unittest.skipIf(getFSVersionTuple() >= (5, 2), 'Only for Plone < 5.2')
+    @unittest.skipIf(PLONE_VERSION >= (5, 2), 'Only for Plone < 5.2')
     def test_quickinstall_uninstallation_removes_resets_configuration(self):
         self._install_dependencies()
 

--- a/ftw/testing/tests/test_mailing.py
+++ b/ftw/testing/tests/test_mailing.py
@@ -42,7 +42,7 @@ class TestMailing(TestCase):
     def test_pop_from_filled_list(self):
         self._send_test_mail()
         message = self.mailing.pop()
-        self.assertIn('info@4teamwork.ch', message)
+        self.assertIn(b'info@4teamwork.ch', message)
 
     def test_get_messages_by_recipient(self):
         self._send_test_mail()
@@ -79,21 +79,22 @@ class TestMailing(TestCase):
         self.assertEquals(
             1, len(Mailing(self.layer['portal']).get_messages()),
             'Expected exactly one email in the MockMailHost.')
-        message = Mailing(self.layer['portal']).pop().split('\n')
+
+        message = Mailing(self.layer['portal']).pop().splitlines()
         self.assertEquals(
             0, len(Mailing(self.layer['portal']).get_messages()),
             'Expected no email in the MockMailHost after popping.')
 
         # replace "Date: ..." - it changes constantly.
-        message = [line.startswith('Date:') and 'Date: ---' or line
+        message = [line.startswith(b'Date:') and b'Date: ---' or line
                    for line in message]
 
         self.assertEquals(
-            ['Subject: A test mail from ftw.testing',
-             'To: info@4teamwork.ch',
-             'From: info@4teamwork.ch',
-             'Date: ---',
-             '',
-             'Hello World'],
+            [b'Subject: A test mail from ftw.testing',
+             b'To: info@4teamwork.ch',
+             b'From: info@4teamwork.ch',
+             b'Date: ---',
+             b'',
+             b'Hello World'],
 
             message)


### PR DESCRIPTION
Fixes the currently failing tests for `ftw.testing`:

- Fix genericsetup uninstall profile test:
  For `Plone >= 5.2` a registry record `custom_css_timestamp` for `plone.app.theming.interfaces.IThemeSettings` exists that screwed up the GS profile snapshot diffing.
  
  That record has both a datetime `value` and a `defaultFactory` with `datetime.now()` that need to be neutralized in order for the diff not to change all the time.  

- Fix mailing tests:
  The email messages captured by the `MockMailHost` are represented as bytestrings.
  
  This is not wrong, since sending mails via Zope's MailHost is very close to SMTP, and over SMTP one transmits *bytes*, not necessarily *text*. SMTP will only ever send 7-bit ASCII over the network, any encoding of non-ASCII characters happens inside the RFC 822 message, using binascii encodings like Base64 or Quoted-Printable.
  
  However, in Python 3 this means those messages also need to be compared to bytestrings, and a comparison like
  
  ```
  self.assertIn('foo@example', messageText)
  ```
  
  will fail with
  
  ```
  TypeError: a bytes-like object is required, not 'str'
  ```
  
  The quick fix therefore is to rewrite the tokens we search for in the messages (in ftw.testings tests) to bytestrings, and call it a day.
  
  In the future we could consider whether we want to change the MockMailHost so that it returns unicode strings, but that didn't immediately work (issues with line endings), and also obscures what's going on.


For [CA-1240](https://4teamwork.atlassian.net/browse/CA-1240)

Fixes test failures like [these](https://ci.4teamwork.ch/builds/540946/tasks/1053505).