### PR TITLE
Use Python 3.8 instead of 3.7 for Plone 5.2 tests.

### DIFF
--- a/test-plone-5.2.x-py37.cfg
+++ b/test-plone-5.2.x-py37.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-plone-5.2.x-py37.cfg
-
-package-name = ftw.testing

--- a/test-plone-5.2.x-py38.cfg
+++ b/test-plone-5.2.x-py38.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-plone-5.2.x-py38.cfg
+
+package-name = ftw.testing


### PR DESCRIPTION
Use Python 3.8 instead of 3.7 for Plone 5.2 tests.

For [CA-2571](https://4teamwork.atlassian.net/browse/CA-2571)